### PR TITLE
Test and publish to GitHub pages

### DIFF
--- a/.github/workflows/publishToGHPages.yml
+++ b/.github/workflows/publishToGHPages.yml
@@ -1,0 +1,42 @@
+name: Run tests and publish to GitHub pages
+
+on:
+  push:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: "16.x"
+      - name: Keep npm cache around to speed up installs
+        uses: actions/cache@v2
+        with:
+          path: ~/.npm
+          key: ${{ runner.OS }}-build-${{ hashFiles('**/package-lock.json') }}
+      - name: Install dependencies
+        run: npm ci --no-audit
+      - name: Compile TypeScript
+        run: npx tsc
+      - name: Run Unit Tests
+        run: npm test
+      - name: Build
+        run: npm run build
+      - uses: actions/upload-artifact@v2
+        with:
+          name: conference-buddy-web-app-${{ github.sha }}
+          path: public
+      - name: Publish to GitHub pages
+        if: github.ref == 'refs/heads/master'
+        run: |
+          echo "machine github.com login accesskey password ${{ secrets.GITHUB_TOKEN }}" > ~/.netrc
+          git config --global user.email "actions@example.com"
+          git config --global user.name "GitHub Actions"
+          cd public
+          git init
+          git add -A
+          git commit -m "update assets"
+          git remote add origin https://github.com/${GITHUB_REPOSITORY}.git
+          git push -f origin HEAD:gh-pages


### PR DESCRIPTION
This adds a GitHub Action workflow that
runs the tests on all commits (including PRs).

If the commit is in 'master' it will
publish the website to the gh-pages branch,
so it can be served.